### PR TITLE
Update CRBRUS decimals in injective.json

### DIFF
--- a/tokenLists/injective.json
+++ b/tokenLists/injective.json
@@ -169,6 +169,6 @@
     "symbol": "CRBRUS",
     "token": "ibc/F8D4A8A44D8EF57F83D49624C4C89EECB1472D6D2D1242818CDABA6BC2479DA9",
     "icon": "/img/CRBRUS.png",
-    "decimals": 18
+    "decimals": 6
   }
 ]


### PR DESCRIPTION
Fixed CRBRUS token decimals. Should be 6 instead of 18, I messed this up in my original PR, sorry for the trouble!