### PR TITLE
Add/fix CRBRUS coingecko ID

### DIFF
--- a/tokenLists/injective.json
+++ b/tokenLists/injective.json
@@ -177,6 +177,7 @@
     "token": "ibc/F8D4A8A44D8EF57F83D49624C4C89EECB1472D6D2D1242818CDABA6BC2479DA9",
     "icon": "/img/CRBRUS.png",
     "decimals": 6
+    "coingeckoId": "cerberus-2"
   },
   {
     "protocol": "Dog wif nunchucks",

--- a/tokenLists/neutron.json
+++ b/tokenLists/neutron.json
@@ -169,7 +169,7 @@
     "token": "ibc/58923AAE6E879D7CB5FB0F2F05550FD4F696099AB0F5CDF0A05CC0309DD8BC78",
     "icon": "/img/CRBRUS.png",
     "decimals": 6,
-    "coingeckoId": "cerberus"
+    "coingeckoId": "cerberus-2"
   },
   {
     "protocol": "Chihuahua",

--- a/tokenLists/sei.json
+++ b/tokenLists/sei.json
@@ -201,6 +201,7 @@
     "token": "ibc/71CEEB5CC09F75A3ACDC417108C14514351B6B2A540ACE9B37A80BF930845134",
     "icon": "/img/CRBRUS.png",
     "decimals": 6
+    "coingeckoId": "cerberus-2"
   },
   {
     "protocol": "Pirate Dog",

--- a/tokenLists/terra2.json
+++ b/tokenLists/terra2.json
@@ -550,5 +550,6 @@
     "token": "ibc/7A6428206CBDE7B47F78A7A8CF4587CDCFD2B3BF06DD0352CEF678E88F1A501D",
     "icon": "/img/CRBRUS.png",
     "decimals": 6
+    "coingeckoId": "cerberus-2"
   }
 ]


### PR DESCRIPTION
Added coingecko ID "cerberus-2" to CRBRUS listings across markets.