### PR TITLE
removed CoingeckoID from MARS.test on pion-1

### DIFF
--- a/tokenLists/testnets/neutron.json
+++ b/tokenLists/testnets/neutron.json
@@ -100,8 +100,6 @@
     "symbol": "MARS.test",
     "token": "factory/neutron1wm8jd0hrw79pfhhm9xmuq43jwz4wtukvxfgkkw/mars",
     "icon": "/img/mars.svg",
-    "coingeckoId": "mars-protocol",
-    "originDenom": "umars",
     "decimals": 6
   },
   {


### PR DESCRIPTION
To enhance the test experience, we need to remove static prices from the `MARS.test` asset