### PR TITLE
Update MARS token after migration

### DIFF
--- a/tokenLists/osmosis.json
+++ b/tokenLists/osmosis.json
@@ -706,13 +706,23 @@
   },
   {
     "protocol": "Mars Protocol",
-    "symbol": "MARS",
+    "symbol": "MARS.old",
     "token": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-    "icon": "/img/mars.svg",
+    "icon": "/img/mars-ibc.svg",
     "decimals": 6,
     "coingeckoId": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
     "originDenom": "umars",
     "originChainId": "mars-1"
+  },
+  {
+    "protocol": "Mars Protocol",
+    "symbol": "MARS",
+    "token": "ibc/B67DF59507B3755EEDE0866C449445BD54B4DA82CCEBA89D775E53DC35664255",
+    "icon": "/img/mars.svg",
+    "decimals": 6,
+    "coingeckoId": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
+    "originDenom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS",
+    "originChainId": "neutron-1"
   },
   {
     "protocol": "Quicksilver",


### PR DESCRIPTION
We have migrated the MARS token from the `mars-1` network to become a native factory token on `neutron-1`. This PR updates the Osmosis token list to reflect these changes.

-  The old token logo for `MARS.old` is now greyed out
-  The new ibc denom is updated along with the `originDenom` to reflect the new token details